### PR TITLE
chore: bump version 1.3.1 → 1.3.2

### DIFF
--- a/Swiftly.xcodeproj/project.pbxproj
+++ b/Swiftly.xcodeproj/project.pbxproj
@@ -618,7 +618,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = fardavide.Swiftly;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -660,7 +660,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = fardavide.Swiftly;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Bumps `MARKETING_VERSION` from `1.3.1` to `1.3.2` to reflect the patch fix for the iOS 26 pull-to-refresh regression merged in the previous PR.

https://claude.ai/code/session_01MFCuDbmyv3BK6UMbZffEYc
EOF
)